### PR TITLE
Update 03_recipe_filter.md ==> add RecipeFilter detail tips

### DIFF
--- a/docs/zh/gunpack/block/03_recipe_filter.md
+++ b/docs/zh/gunpack/block/03_recipe_filter.md
@@ -5,7 +5,7 @@ order: 3
 配方过滤器用于筛选合成台包含的配方，以便于玩家在合成台中只看到某些特定配方。  
 
 :::tip
-过滤器检索的字段是配方的完整id字符串，比如`tutorial:gun/ak47`。
+过滤器检索的字段是配方的完整id字符串，比如`tutorial:gun/ak47`, 如果希望添加进白名单的是枪械，则一般是以gun作为前缀，比如`tutorial:gun/ak47`，如果是配件，则以attachments作为前缀，比如：`tutorial:attachments/ak47-scope`, 如果是子弹，则以ammo作为前缀，比如：`tutorial:ammo/762x39`
 :::
 
 ## 定义一个配方过滤器


### PR DESCRIPTION
想将配件和枪械加入枪械合成台的配方中发现只有枪械生效了，配件一个都没加进去，后面才发现要添加配件前缀**要写attachments而不是attachment**........[I'm stupid!!]
补充了合成配方过滤器添加配件和子弹的方法描述，希望不要有第二个倒霉蛋因为attachments和attachment的问题去调试代码了（悲!）
